### PR TITLE
Delete redundant arrays to reduce allocated memory

### DIFF
--- a/chains/ethereum/header_store.go
+++ b/chains/ethereum/header_store.go
@@ -53,7 +53,7 @@ type HeaderStore struct {
 	CanonicalNumberToHash map[uint64]common.Hash
 	CurNumber             uint64
 	CurHash               common.Hash
-	HeaderNumber          []*big.Int
+	//HeaderNumber          []*big.Int
 }
 
 type LightHeader struct {
@@ -66,16 +66,16 @@ func headerKey(number uint64, hash common.Hash) string {
 }
 
 func (hs *HeaderStore) delOldHeaders() {
-	length := len(hs.HeaderNumber)
-	log.Info("delOld -------------- length", "length", length, "height", hs.CurNumber)
-	if length <= MaxHeaderLimit {
-		return
-	}
+	//length := len(hs.HeaderNumber)
+	//log.Info("delOld -------------- length", "length", length, "height", hs.CurNumber)
+	//if length <= MaxHeaderLimit {
+	//	return
+	//}
 
-	delTotal := length - MaxHeaderLimit
-	hs.HeaderNumber = hs.HeaderNumber[delTotal:]
-	log.Info("before cleaning up the old ethereum headers", "headers length", length)
-	log.Info("after cleaning up the old ethereum headers", "headers length", len(hs.HeaderNumber))
+	//delTotal := length - MaxHeaderLimit
+	//hs.HeaderNumber = hs.HeaderNumber[delTotal:]
+	//log.Info("before cleaning up the old ethereum headers", "headers length", length)
+	//log.Info("after cleaning up the old ethereum headers", "headers length", len(hs.HeaderNumber))
 }
 
 func encodeHeader(header *Header) []byte {
@@ -98,7 +98,7 @@ func decodeHeader(data []byte, hash common.Hash) *Header {
 func NewHeaderStore() *HeaderStore {
 	return &HeaderStore{
 		CanonicalNumberToHash: make(map[uint64]common.Hash),
-		HeaderNumber:          make([]*big.Int, 0, MaxHeaderLimit), // 数组舍弃多少个，还是通过下标的方式
+		//HeaderNumber:          make([]*big.Int, 0, MaxHeaderLimit), // 数组舍弃多少个，还是通过下标的方式
 	}
 }
 
@@ -116,11 +116,11 @@ func (hs *HeaderStore) ResetHeaderStore(state types.StateDB, ethHeaders []byte, 
 		CanonicalNumberToHash: map[uint64]common.Hash{
 			number: hash,
 		},
-		CurHash:      hash,
-		CurNumber:    number,
-		HeaderNumber: make([]*big.Int, 0, MaxHeaderLimit),
+		CurHash:   hash,
+		CurNumber: number,
+		//HeaderNumber: make([]*big.Int, 0, MaxHeaderLimit),
 	}
-	h.HeaderNumber = append(h.HeaderNumber, header.Number)
+	//h.HeaderNumber = append(h.HeaderNumber, header.Number)
 	if err := h.Store(state); err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (hs *HeaderStore) Store(state types.StateDB) error {
 		return err
 	}
 
-	log.Info("Store save ", "curNumber", hs.CurNumber, "length", len(hs.HeaderNumber))
+	//log.Info("Store save ", "curNumber", hs.CurNumber, "length", len(hs.HeaderNumber))
 	state.SetPOWState(address, key, data)
 
 	clone, err := cloneHeaderStore(hs)
@@ -213,8 +213,8 @@ func (hs *HeaderStore) Load(state types.StateDB) (err error) {
 		}
 		h = *cp
 		hs.CurHash, hs.CurNumber = h.CurHash, h.CurNumber
-		hs.CanonicalNumberToHash, hs.HeaderNumber = h.CanonicalNumberToHash, h.HeaderNumber
-		log.Info("Load cache ", "curNumber", hs.CurNumber, "length", len(hs.HeaderNumber))
+		hs.CanonicalNumberToHash = h.CanonicalNumberToHash
+		//hs.CanonicalNumberToHash, hs.HeaderNumber = h.CanonicalNumberToHash, h.HeaderNumber
 		return nil
 	}
 
@@ -229,7 +229,8 @@ func (hs *HeaderStore) Load(state types.StateDB) (err error) {
 	}
 	storeCache.Cache.Add(hash, clone)
 	hs.CurHash, hs.CurNumber = h.CurHash, h.CurNumber
-	hs.CanonicalNumberToHash, hs.HeaderNumber = h.CanonicalNumberToHash, h.HeaderNumber
+	//hs.CanonicalNumberToHash, hs.HeaderNumber = h.CanonicalNumberToHash, h.HeaderNumber
+	hs.CanonicalNumberToHash = h.CanonicalNumberToHash
 	return nil
 }
 
@@ -274,7 +275,7 @@ func (hs *HeaderStore) WriteHeaderAndTd(hash common.Hash, number uint64, td *big
 	}
 	loadHeader.Headers[hash.String()] = encodeHeader(header)
 	loadHeader.TDs[hash.String()] = td
-	hs.HeaderNumber = append(hs.HeaderNumber, header.Number)
+	//hs.HeaderNumber = append(hs.HeaderNumber, header.Number)
 	// store
 	return hs.StoreHeader(db, number, loadHeader)
 }

--- a/chains/ethereum/header_store_ext.go
+++ b/chains/ethereum/header_store_ext.go
@@ -10,28 +10,28 @@ import (
 )
 
 type extHeaderStore struct {
-	Numbers      []uint64
-	Hashes       []common.Hash
-	HeadersKey   []*big.Int
-	HeadersValue [][]byte
-	TDsKey       []*big.Int
-	TDsValue     []*big.Int
-	CurNumber    uint64
-	CurHash      common.Hash
+	Numbers []uint64
+	Hashes  []common.Hash
+	//HeadersKey   []*big.Int
+	//HeadersValue [][]byte
+	//TDsKey       []*big.Int
+	//TDsValue     []*big.Int
+	CurNumber uint64
+	CurHash   common.Hash
 }
 
 func (hs *HeaderStore) EncodeRLP(w io.Writer) error {
 	var (
 		cl = len(hs.CanonicalNumberToHash)
-		hl = len(hs.HeaderNumber)
-		tl = len(hs.HeaderNumber)
+		//hl = len(hs.HeaderNumber)
+		//tl = len(hs.HeaderNumber)
 	)
 
 	var (
-		Numbers    = make([]uint64, 0, cl)
-		Hashes     = make([]common.Hash, 0, cl)
-		HeadersKey = make([]*big.Int, 0, hl)
-		TDsKey     = make([]*big.Int, 0, tl)
+		Numbers = make([]uint64, 0, cl)
+		Hashes  = make([]common.Hash, 0, cl)
+		//HeadersKey = make([]*big.Int, 0, hl)
+		//TDsKey     = make([]*big.Int, 0, tl)
 	)
 
 	for number := range hs.CanonicalNumberToHash {
@@ -44,21 +44,21 @@ func (hs *HeaderStore) EncodeRLP(w io.Writer) error {
 		Hashes = append(Hashes, hs.CanonicalNumberToHash[number])
 	}
 
-	for _, k := range hs.HeaderNumber {
-		HeadersKey = append(HeadersKey, k)
-	}
-
-	for _, k := range hs.HeaderNumber {
-		TDsKey = append(TDsKey, k)
-	}
+	//for _, k := range hs.HeaderNumber {
+	//	HeadersKey = append(HeadersKey, k)
+	//}
+	//
+	//for _, k := range hs.HeaderNumber {
+	//	TDsKey = append(TDsKey, k)
+	//}
 
 	return rlp.Encode(w, extHeaderStore{
-		Numbers:    Numbers,
-		Hashes:     Hashes,
-		HeadersKey: HeadersKey,
-		TDsKey:     TDsKey,
-		CurNumber:  hs.CurNumber,
-		CurHash:    hs.CurHash,
+		Numbers: Numbers,
+		Hashes:  Hashes,
+		//HeadersKey: HeadersKey,
+		//TDsKey:     TDsKey,
+		CurNumber: hs.CurNumber,
+		CurHash:   hs.CurHash,
 	})
 }
 
@@ -69,17 +69,18 @@ func (hs *HeaderStore) DecodeRLP(s *rlp.Stream) error {
 	}
 
 	CanonicalNumberToHash := make(map[uint64]common.Hash)
-	headerNumber := make([]*big.Int, 0, len(eh.HeadersKey))
+	//headerNumber := make([]*big.Int, 0, len(eh.HeadersKey))
 
 	for i, number := range eh.Numbers {
 		CanonicalNumberToHash[number] = eh.Hashes[i]
 	}
-	for _, v := range eh.HeadersKey {
-		headerNumber = append(headerNumber, v)
-	}
+	//for _, v := range eh.HeadersKey {
+	//	headerNumber = append(headerNumber, v)
+	//}
 
 	hs.CurNumber, hs.CurHash = eh.CurNumber, eh.CurHash
-	hs.CanonicalNumberToHash, hs.HeaderNumber = CanonicalNumberToHash, headerNumber
+	//hs.CanonicalNumberToHash, hs.HeaderNumber = CanonicalNumberToHash, headerNumber
+	hs.CanonicalNumberToHash = CanonicalNumberToHash
 	return nil
 }
 


### PR DESCRIPTION
When synchronizing headers across the chain, the memory remains high. It is found that the memory allocated to extHeaderStore is too high. Currently, redundant arrays are deleted to reduce the allocated memory. It is tested that 10000 headers were synchronized, using about 4G of memory, and currently 1G of memory

